### PR TITLE
Rename run_pending_migs to run_pending_migrations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Diesel Async Migs
+# Diesel Async Migrations
 
 Handles Postgres migrations via async diesel
 
@@ -12,7 +12,7 @@ pub const MIGRATIONS: diesel_async_migrations::EmbeddedMigrations = diesel_async
 
 async fn run_migrations(url: impl AsRef<str>) -> anyhow::Result<()> {
     let mut conn = AsyncConnection::establish(url.as_ref()).await?;
-    MIGRATIONS.run_pending_migs(&mut conn).await?;
+    MIGRATIONS.run_pending_migrations(&mut conn).await?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl EmbeddedMigrations {
         Ok(())
     }
 
-    pub async fn run_pending_migs<C>(&self, conn: &mut C) -> Result<()>
+    pub async fn run_pending_migrations<C>(&self, conn: &mut C) -> Result<()>
     where
         C: AsyncConnection<Backend = diesel::pg::Pg> + 'static + Send,
     {


### PR DESCRIPTION
Enables drop-in replacement with the sync version.