### PR TITLE
removed setup_attempted flag

### DIFF
--- a/macros/src/embed_migrations.rs
+++ b/macros/src/embed_migrations.rs
@@ -15,11 +15,11 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
         .unwrap_or_else(|_| {
             panic!("Failed to receive migrations dir from {migrations_path_opt:?}",)
         });
-    let embeded_migrations =
+    let embedded_migrations =
         migration_literals_from_path(&migrations_expr).expect("Failed to read migration literals");
 
     quote! {
-        diesel_async_migrations::EmbeddedMigrations{migrations: &[#(#embeded_migrations,)*], setup_attempted: std::sync::atomic::AtomicU8::new(0), }
+        diesel_async_migrations::EmbeddedMigrations{migrations: &[#(#embedded_migrations,)*], }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::atomic::{AtomicU8, Ordering},
-};
+use std::collections::HashMap;
 
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, RunQueryDsl};
@@ -41,7 +38,6 @@ impl EmbeddedMigration {
 #[derive(Debug)]
 pub struct EmbeddedMigrations {
     pub migrations: &'static [EmbeddedMigration],
-    pub setup_attempted: AtomicU8,
 }
 
 impl EmbeddedMigrations {
@@ -49,13 +45,7 @@ impl EmbeddedMigrations {
     where
         C: AsyncConnection<Backend = diesel::pg::Pg>,
     {
-        if self.setup_attempted.fetch_add(1, Ordering::SeqCst) != 0 {
-            return Ok(());
-        }
-
-        conn.batch_execute(CREATE_MIGRATIONS_TABLE).await?;
-
-        Ok(())
+        conn.batch_execute(CREATE_MIGRATIONS_TABLE).await
     }
 
     pub async fn run_pending_migrations<C>(&self, conn: &mut C) -> Result<()>


### PR DESCRIPTION
First of all, thank you for your great work here!

I am the author of the [`db-pool`](https://github.com/yasamoka/db-pool) crate and I have a use case that requires database migrations to run multiple times during the lifetime of the program. In my case, I am running database migrations once for every new test database that gets created. The relevant example is found [here](https://github.com/yasamoka/db-pool/blob/main/examples/async-graphql/main.rs#L158-L194).

However, the problem is that there is a flag that stores whether database migrations have run once and causes `conn.batch_execute(CREATE_MIGRATIONS_TABLE).await` to be skipped after the first time. When running the actual migrations, an error occurs stating that the `__diesel_schema_migrations` table does not exist for any database after the first one created.

I believe it should be the programmer's responsibility to ensure that database migrations run only once. It could be part of the program flow or, just to be sure, it could be a flag much in the same way that `setup_attempted` works. This removes the assumption that migrations run once and permits the possibility of using the same embedded migrations multiple times within the same program.

Much appreciated.